### PR TITLE
Update urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pbr==1.10.0
 requests==2.20.1
 simplejson==3.16.0
 six==1.11.0
-urllib3==1.24.1
+urllib3==1.24.3


### PR DESCRIPTION
The `requirements.txt` file is only used for running the tests but this should stop Github from sending security vulnerability warnings every week.

@ustudio/reviewers Please review