### PR TITLE
Use CircleCI Contexts for Credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,4 +78,4 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*.*/
             branches:
               ignore: /.*/
-          context: org-global
+          context: datadog-logger-publisher

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 attrs==21.2.0
-certifi==2021.5.30
+certifi==2022.12.7
 chardet==4.0.0
 datadog==0.41.0
 decorator==5.0.9


### PR DESCRIPTION
This PR updates the CircleCI configuration to use a specific context for accessing PyPI credentials, which is easier to manage and more secure.

@ustudio/reviewers Please review