### PR TITLE
Handle Errors When Sending Events to Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # DataDog Logger #
 
-A Python `logging.Handler` for sending log messages to DataDog as
-Events
+Note: This library does not send logs to Datadog's Log Management product. See
+Datadog's documentation for how to configure log collection. See
+https://docs.datadoghq.com/logs/log_collection/
+
+A Python `logging.Handler` for sending log messages to DataDog as Events in
+the Events Explorer.
 
 ## Installation ##
 

--- a/datadog_logger/handler.py
+++ b/datadog_logger/handler.py
@@ -26,20 +26,24 @@ class DatadogLogHandler(logging.Handler):
         self.mentions = mentions
 
     def emit(self, record: logging.LogRecord) -> None:
-        text = self.format(record)
+        try:
+            text = self.format(record)
 
-        if self.mentions is not None:
-            text = "\n\n".join([text, " ".join(self.mentions)])
+            if self.mentions is not None:
+                text = "\n\n".join([text, " ".join(self.mentions)])
 
-        create_args: dict[str, object] = {
-            "title": record.getMessage(),
-            "text": text
-        }
+            create_args: dict[str, object] = {
+                "title": record.getMessage(),
+                "text": text
+            }
 
-        if self.tags is not None:
-            create_args["tags"] = self.tags
+            if self.tags is not None:
+                create_args["tags"] = self.tags
 
-        if record.levelno in LOG_LEVEL_ALERT_TYPE_MAPPINGS:
-            create_args["alert_type"] = LOG_LEVEL_ALERT_TYPE_MAPPINGS[record.levelno]
+            if record.levelno in LOG_LEVEL_ALERT_TYPE_MAPPINGS:
+                create_args["alert_type"] = LOG_LEVEL_ALERT_TYPE_MAPPINGS[record.levelno]
 
-        Event.create(**create_args)  # type: ignore[no-untyped-call]
+            Event.create(**create_args)  # type: ignore[no-untyped-call]
+
+        except Exception:
+            self.handleError(record)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datadog-logger"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python logging handler for DataDog events"
 authors = ["uStudio Developers <dev@ustudio.com>"]
 license = "MIT"

--- a/tests/test_datadog_logger.py
+++ b/tests/test_datadog_logger.py
@@ -196,3 +196,22 @@ class TestDatadogLogger(TestCase):
         mock_event_class.create.assert_called_once_with(
             title="Should be logged", text="Should be logged\n\n@mention",
             tags=["some:tag"], alert_type="error")
+
+    @mock.patch("logging.Handler.handleError", autospec=True)
+    @mock.patch("datadog_logger.handler.Event", autospec=True)
+    def test_emit_calls_handle_error_when_it_raises_an_exception(
+        self,
+        mock_event_class: mock.Mock,
+        mock_handle_error: mock.Mock
+    ) -> None:
+        mock_event_class.create.side_effect = Exception("event create error")
+
+        handler = DatadogLogHandler()
+
+        record = logging.makeLogRecord({
+            "msg": "Some message"
+        })
+
+        handler.emit(record)
+
+        mock_handle_error.assert_called_once_with(handler, record)


### PR DESCRIPTION
This PR updates the `DatadogLogHandler` class to handle errors raised inside `emit` and send them to the `handleError` method, so that the exceptions don't bubble up to the application and the exceptions can be reported by the base Handler, if desired.

We also updated the README to clarify that this library is not intended for sending logs into Datadog's Log Management product, since that has been a source of confusion for people, in the past.

@ustudio/reviewers Please review